### PR TITLE
PENGSOL-248 fix open transactions when initializing dwh connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ source .venv/bin/activate
 ```
 
 3. Install dependencies
-   As this is a python package, dependencies are in setyp.py (actually in setup.cfg, as this is a pyScaffold project). Requirements.txt will perform the correct installation and add a couple of
-   additional packages
+   As this is a python package, dependencies are in setup.py (actually in setup.cfg, as this is a pyScaffold project). 
+   Requirements.txt will perform the correct installation and add a couple of additional packages.
+   The second command installs the packages required for running tests.
 
 ```
 pip install -r requirements.txt
+pip install -e ".[testing]"
 ```
 
 4. Run tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,17 +51,13 @@ allowlist_externals = python
 # For more information, check out https://semver.org/.
 install_requires =
     importlib-metadata; python_version<"3.9"
-    requests >= 2.28.1
-    pydantic >= 2.0
-    email-validator >= 2.0.0
-    paramiko >= 3.3.1
-    jinja2 >= 3.0.1    
-    pandas >= 1.4.4
-    pyodbc
-    pytest
-    pytest-cov
-    pytest-mock
-    pyarrow
+    requests >= 2.28.1, <3.0
+    pydantic >= 2.0, <3.0
+    email-validator >= 2.0.0, <3.0
+    paramiko >= 3.3.1, <4.0
+    jinja2 >= 3.0.1, <4.0
+    pandas >= 1.4.4, <3.0
+    pyodbc <6.0.0
 
 
 [options.packages.find]
@@ -76,10 +72,11 @@ exclude =
 
 # Add here test requirements (semicolon/line-separated)
 testing =
-    setuptools
-    pytest
-    pytest-cov
-    pytest-mock
+    setuptools <76.0.0
+    pytest <9.0.0
+    pytest-cov <6.0.0
+    pytest-mock <4.0.0
+    pyarrow <17.0.0
 
 [options.entry_points]
 # Add here console scripts like:

--- a/src/pyprediktorutilities/dwh/dwh.py
+++ b/src/pyprediktorutilities/dwh/dwh.py
@@ -58,9 +58,8 @@ class Dwh:
         )
         self.connection_attempts = 3
 
-        self.__connect()
-
     def __enter__(self):
+        self.__connect()
         return self
 
     @validate_call
@@ -115,6 +114,7 @@ class Dwh:
             if not self.cursor.nextset():
                 break
 
+        self.__disconnect()  # prevent from leaving open transactions in DWH
         return data_sets if len(data_sets) > 1 else data_sets[0]
 
     @validate_call
@@ -151,7 +151,7 @@ class Dwh:
             pass
 
         self.__commit()
-
+        self.__disconnect()  # prevent from leaving open transactions in DWH
         return result
 
     """
@@ -226,7 +226,7 @@ class Dwh:
             try:
                 self.connection = pyodbc.connect(self.connection_string)
                 self.cursor = self.connection.cursor()
-                logging.info("Connection successfull!")
+                logging.info("Connection successful!")
                 break
 
             # Exceptions once thrown there is no point attempting


### PR DESCRIPTION
The PR consists of:
- close opened transactions when using fetch/execute methods (followed by Jørn's report: https://tgs.atlassian.net/browse/PENGSOL-248)
- fixed using `Dwh` as context manager
- update test cases (ensure that transactions are closed)
- lock dependencies' versions
- separate test dependencies from library dependencies
- add a note in the readme file on how the test dependencies should be installed