### PR TITLE
PENGSOL-555 Fix open transaction issue in measurement and forecast API

### DIFF
--- a/src/pyprediktorutilities/dwh/dwh.py
+++ b/src/pyprediktorutilities/dwh/dwh.py
@@ -144,15 +144,13 @@ class Dwh:
         """
         self.__connect()
         try:
-            try:
-                self.cursor.execute(query, *args, **kwargs)
-                result = self.cursor.fetchall()
-            except Exception as e:
-                logging.error(f"Failed to execute query: {e}")
-                return []
-
+            self.cursor.execute(query, *args, **kwargs)
+            result = self.cursor.fetchall()
             self.__commit()
             return result
+        except Exception as e:
+            logging.error(f"Failed to execute query: {e}")
+            return []
         finally:
             self.__disconnect()  # prevent from leaving open transactions in DWH
 

--- a/src/pyprediktorutilities/dwh/dwh.py
+++ b/src/pyprediktorutilities/dwh/dwh.py
@@ -98,23 +98,25 @@ class Dwh:
                 is going to be in DataFrame format.
         """
         self.__connect()
-        self.cursor.execute(query)
+        try:
+            self.cursor.execute(query)
 
-        data_sets = []
-        while True:
-            columns = [col[0] for col in self.cursor.description]
-            data_set = [dict(zip(columns, row)) for row in self.cursor.fetchall()]
+            data_sets = []
+            while True:
+                columns = [col[0] for col in self.cursor.description]
+                data_set = [dict(zip(columns, row)) for row in self.cursor.fetchall()]
 
-            if to_dataframe:
-                data_sets.append(pd.DataFrame(data_set, columns=columns))
-            else:
-                data_sets.append(data_set)
+                if to_dataframe:
+                    data_sets.append(pd.DataFrame(data_set, columns=columns))
+                else:
+                    data_sets.append(data_set)
 
-            if not self.cursor.nextset():
-                break
+                if not self.cursor.nextset():
+                    break
 
-        self.__disconnect()  # prevent from leaving open transactions in DWH
-        return data_sets if len(data_sets) > 1 else data_sets[0]
+            return data_sets if len(data_sets) > 1 else data_sets[0]
+        finally:
+            self.__disconnect()  # prevent from leaving open transactions in DWH
 
     @validate_call
     def execute(self, query: str, *args, **kwargs) -> List[Any]:
@@ -142,15 +144,17 @@ class Dwh:
         """
         self.__connect()
         try:
-            self.cursor.execute(query, *args, **kwargs)
-            result = self.cursor.fetchall()
-        except Exception as e:
-            logging.error(f"Failed to execute query: {e}")
-            return []
+            try:
+                self.cursor.execute(query, *args, **kwargs)
+                result = self.cursor.fetchall()
+            except Exception as e:
+                logging.error(f"Failed to execute query: {e}")
+                return []
 
-        self.__commit()
-        self.__disconnect()  # prevent from leaving open transactions in DWH
-        return result
+            self.__commit()
+            return result
+        finally:
+            self.__disconnect()  # prevent from leaving open transactions in DWH
 
     """
     Private - Driver


### PR DESCRIPTION
[JIRA](https://tgs.atlassian.net/browse/PENGSOL-555)
[Trello](https://trello.com/c/8EwQjCeA/2084-fix-open-transaction-issue-in-measurement-and-forecast-api)

# What was fixed?
When executing a query or fetching data from the database, always use try-finally. Inside finally, the block always executes disconnect.

# More details
When executing a query, there are cases, to have an exception inside method `fetch` and `execute`. In those cases, the method `__disconnect` may not be executed. This is why we have to use a try-finally block. This ensures that the method `__disconnect` will always be executed and the connection to the database will be closed.