### PR TITLE
PENGSOL-483: Fix driver assigning

### DIFF
--- a/src/pyprediktorutilities/dwh/dwh.py
+++ b/src/pyprediktorutilities/dwh/dwh.py
@@ -47,17 +47,18 @@ class Dwh:
         self.password = password
         self.connection = None
 
-        self.connection_string = (
+        self.connection_string_template = (
             f"UID={self.username};"
             + f"PWD={self.password};"
-            + f"DRIVER={self.driver};"
+            + "DRIVER={};"
             + f"SERVER={self.url};"
             + f"DATABASE={self.database};"
             + "TrustServerCertificate=yes;"
         )
-        self.connection_attempts = 3
-
         self.__set_driver(driver_index)
+        self.connection_string = self.connection_string_template.format(self.driver)
+
+        self.connection_attempts = 3
 
     def __enter__(self):
         self.__connect()
@@ -203,7 +204,10 @@ class Dwh:
 
         for driver in supported_drivers:
             try:
-                pyodbc.connect(self.connection_string, timeout=3)
+                connection_string_with_assigned_driver = (
+                    self.connection_string_template.format(driver)
+                )
+                pyodbc.connect(connection_string_with_assigned_driver, timeout=3)
                 available_drivers.append(driver)
             except pyodbc.Error as err:
                 logger.info(f"Driver {driver} could not connect: {err}")

--- a/tests/dwh/test_dwh.py
+++ b/tests/dwh/test_dwh.py
@@ -687,6 +687,21 @@ class TestDwh:
                 helpers.grs(), helpers.grs(), helpers.grs(), helpers.grs(), driver_index
             )
 
+    def test_init_sets_driver_into_connection_string(self, monkeypatch):
+        driver_name = "MY_MSSQL_DRIVER"
+        monkeypatch.setattr("pyodbc.drivers", lambda: [driver_name])
+        monkeypatch.setattr(
+            dwh.Dwh,
+            "_Dwh__get_list_of_available_and_supported_pyodbc_drivers",
+            lambda self: {"available": [driver_name], "supported": [driver_name]},
+        )
+
+        dwh_instance = dwh.Dwh(
+            helpers.grs(), helpers.grs(), helpers.grs(), helpers.grs()
+        )
+
+        assert driver_name in dwh_instance.connection_string
+
     @mock.patch("pyodbc.connect")
     def test_context_manager_enter(self, _, dwh_instance):
         assert dwh_instance.__enter__() == dwh_instance


### PR DESCRIPTION
The fix prevents connection errors when MSSQL driver is empty in the DWH connection string