### PR TITLE
PENGSOL-587 DWH class raises-exception

### DIFF
--- a/src/pyprediktorutilities/dwh/dwh.py
+++ b/src/pyprediktorutilities/dwh/dwh.py
@@ -116,6 +116,9 @@ class Dwh:
                     break
 
             return data_sets if len(data_sets) > 1 else data_sets[0]
+        except Exception as e:
+            logging.error(f"Failed to fetch data: {e}")
+            raise
         finally:
             self.__disconnect()  # prevent from leaving open transactions in DWH
 
@@ -151,7 +154,7 @@ class Dwh:
             return result
         except Exception as e:
             logging.error(f"Failed to execute query: {e}")
-            return []
+            raise
         finally:
             self.__disconnect()  # prevent from leaving open transactions in DWH
 

--- a/tests/dwh/test_dwh.py
+++ b/tests/dwh/test_dwh.py
@@ -759,10 +759,8 @@ class TestDwh:
     def test_execute_with_fetch_error(self, dwh_instance, mock_pyodbc_connect, caplog):
         mock_pyodbc_connect.fetchall.side_effect = Exception("Fetch error")
 
-        result = dwh_instance.execute("SELECT * FROM test_table")
-
-        assert result == []
-        assert "Failed to execute query: Fetch error" in caplog.text
+        with pytest.raises(Exception):
+            dwh_instance.execute("SELECT * FROM test_table")
 
     def test_set_driver_with_valid_index(self, monkeypatch):
         available_drivers = {


### PR DESCRIPTION
[JIRA](https://tgs.atlassian.net/browse/PENGSOL-587)
[Trello](https://trello.com/c/c7iFDyDd/2142-maf-cron-job-is-not-working-after-upgrade?filter=member:paveltashev)

We'd like DWH class and in particular `fetch` and `execute` methods to raise exceptions. In this way, the exception will be propagated up to the place where we use that class and we will be able to detect issues with the database connection.