### PR TITLE
PENGSOL-587-check-if-dwh-returns-results

### DIFF
--- a/src/pyprediktorutilities/dwh/dwh.py
+++ b/src/pyprediktorutilities/dwh/dwh.py
@@ -149,7 +149,13 @@ class Dwh:
         self.__connect()
         try:
             self.cursor.execute(query, *args, **kwargs)
-            result = self.cursor.fetchall()
+
+            # Check if the cursor has a description attribute, indicating a result set
+            if self.cursor.description:
+                result = self.cursor.fetchall()
+            else:
+                result = []
+
             self.__commit()
             return result
         except Exception as e:


### PR DESCRIPTION
[JIRA](https://tgs.atlassian.net/browse/PENGSOL-587)
[Trello](https://trello.com/c/c7iFDyDd/2142-maf-cron-job-is-not-working-after-upgrade)

When executing the `execute` method, we check for any results. If there are, we only execute `fetchall` to prevent throwing exceptions.